### PR TITLE
Scroll back to top when node changes

### DIFF
--- a/UsbongKit/Nodes/NodeView.swift
+++ b/UsbongKit/Nodes/NodeView.swift
@@ -18,6 +18,7 @@ public class NodeView: UIView {
     public var node: Node = TextNode(text: "No Node") {
         didSet {
             tableView.reloadData()
+            tableView.scrollToRowAtIndexPath(NSIndexPath(forRow: 0, inSection: 0), atScrollPosition: .Top, animated: false)
         }
     }
     


### PR DESCRIPTION
Fixes issue #15.

I added code to manually scroll to the first row:

```swift
tableView.scrollToRowAtIndexPath(NSIndexPath(forRow: 0, inSection: 0), atScrollPosition: .Top, animated: false)
```